### PR TITLE
Allow templating with stdin/stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test: $(EXECFILE)
 	rm -rf $(TEST_DEST_DIR)
 	mkdir $(TEST_DEST_DIR)
 	./$(EXECFILE) $(TEST_RULES) $(TEST_DOTFILES) $(TEST_DEST_DIR) $(TEST_IGNORE_ARG); \
+	cat $(TEST_DOTFILES)/template | ./$(EXECFILE) $(TEST_RULES) > $(TEST_DEST_DIR)/stdout; \
 	diff $(DIFF_FLAGS) $(TEST_DEST_DIR) $(TEST_EXPECTED_DIR)
 	if [ ! -x "$(TEST_DEST_DIR)/binary_file" ]; then \
 		@echo "Expected binary_file to be executable."; \

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 A small, portable Rust program intended for templating dotfiles across multiple systems.
 
 ## Purpose
-Storing dotfiles in git repositories allows them to be shared across multiple computers, but this becomes problematic once systems require slightly different configurations. Laptops require battery indicators and WiFi utilities, HiDPI displays use larger fonts... `dot-templater` intends to solve these problems by making it simple to change values or enable/disable chunks of configuration in any file.
+Storing dotfiles in git repositories allows them to be shared across multiple computers, but this becomes problematic once systems require slightly different configurations. Laptops require battery indicators and WiFi utilities, HiDPI displays use larger fonts... `dot-templater` intends to solve these problems by making it simple to change values or enable/disable chunks of configuration in any file, or content from stdin.
 
 ## Features
-* Make string substitutions in files according to configured key/value pairs.
+* Make string substitutions in files/content according to configured key/value pairs.
 * Use output from arbitrary shell commands in templated dotfiles (e.g. for passwords with GNU Pass).
-* Toggle chunks of files per feature flags.
+* Toggle chunks of files/content per feature flags.
 * Copy binary files without templating.
 * Preserve file permissions.
 * Perform a dry-run to compare expected output against existing files.
@@ -29,6 +29,12 @@ dot-templater CONFIG SRC_DIR DEST_DIR
 ```
 
 Copies files from `SRC_DIR` to `DEST_DIR` according to rules in `CONFIG`.
+
+```
+dot-templater CONFIG
+```
+
+Templates content from stdin to stdout according to rules in `CONFIG`.
 
 ```
 dot-templater --diff CONFIG SRC_DIR DEST_DIR

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use dot_templater::Config;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::io::{self};
 use std::process;
 
 fn main() {
@@ -24,13 +25,11 @@ fn main() {
         .arg(
             Arg::with_name("SRC_DIR")
                 .help("Path to directory containing template files")
-                .required(true)
                 .index(2),
         )
         .arg(
             Arg::with_name("DEST_DIR")
                 .help("Path to generate output files in")
-                .required(true)
                 .index(3),
         )
         .arg(
@@ -74,9 +73,16 @@ fn main() {
         process::exit(1);
     });
 
-    dot_templater::template(&config, &args.source, &args.dest, args.diff, args.ignore)
-        .unwrap_or_else(|err| {
-            eprintln!("Error while performing templating: {}", err);
-            process::exit(1);
-        });
+    if args.source.is_some() && args.dest.is_some() {
+        let source = &args.source.unwrap();
+        let dest = &args.dest.unwrap();
+
+        dot_templater::template(&config, &source, &dest, args.diff, args.ignore)
+    } else {
+        dot_templater::template_lines(&config, io::stdin().lock().lines())
+    }
+    .unwrap_or_else(|err| {
+        eprintln!("Error while performing templating: {}", err);
+        process::exit(1);
+    });
 }


### PR DESCRIPTION
This allows one to send data in via stdin and receive it via stdout. This mode is only invoked in the absence of the originally required arguments of input and output paths.

Todo:

- [x] Make the test system support this mode
- [x] Update documentation
- [ ] Decide if this is the best interface to go with. One might argue this is a breaking change because omitting all arguments and supplying no stdin will cause the program to hang (because it's expecting to eventually see input). Maybe an explicit `--stdin` argument or similar would be preferable.

Resolves https://github.com/kesslern/dot-templater/issues/23